### PR TITLE
app not finding bower resources when using spring boot

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "src/main/webapp/bower_components"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ deploy/
 .DS_Store
 .classpath
 bin
+src/main/webapp/bower_components

--- a/Readme.md
+++ b/Readme.md
@@ -24,9 +24,21 @@ By default, the application will attempt to use a Neo4j instance running on the 
 Start Neo4j
 -----------
 
-Now start your Neo4j server instance, if its not already running. 
+Now start your Neo4j server instance, if its not already running.
 
 **You should back up any data you want to keep because the application will purge any existing data first**
+
+Download the application
+------------------------
+
+```
+git clone git@github.com:neo4j-examples/neo4j-ogm-university
+cd neo4j-ogm-university
+bower install
+```
+
+The static resources defined in the `bower.json` file will be installed under the `$DIR/src/main/webapp/bower_components` directory. This directory is
+ignored by `git`.
 
 Starting the application
 ------------------------
@@ -84,9 +96,3 @@ Visit the node.js website for details of installing node.js for your particular 
 Once node is installed you'll then need to grab the following npm packages:
 
     npm install --global bower grunt-cli
-
-
-
-
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -120,4 +120,3 @@
     </pluginRepositories>
 
 </project>
-


### PR DESCRIPTION
When starting the application with `mvn spring-boot:run` the webserver is starting but the web application try to find the bower assets in `$PROJECT_DIR/src/main/webapp/bower_components` while when using `bower install` they are installed under `$PROJECT_DIR/bower_components`.

This PR mainly add a bower configuration file to install the bower assets in the looked up directory and adds this directory in the `.gitignore` file.
